### PR TITLE
Remove dry_run argument from update as it didn't produce output

### DIFF
--- a/conda_tracker/cli.py
+++ b/conda_tracker/cli.py
@@ -45,14 +45,13 @@ def add(organization, aggregate_repository, token):
 
 @cli.command()
 @click.argument('repository', required=False)
-@click.option('--dry-run', is_flag=True)
-def update(repository, dry_run):
+def update(repository):
     """Update all submodules inside the given aggregate repository.
 
     Example:
     $  conda-tracker update
     """
-    library.update_submodules(repository, dry_run)
+    library.update_submodules(repository)
 
 
 @cli.command()


### PR DESCRIPTION
This will fix the failing test in the Python 3.6 environment.