### PR TITLE
Add remove_submodule function and require aggregate repository argument in CLI update subcommand

### DIFF
--- a/conda_tracker/cli.py
+++ b/conda_tracker/cli.py
@@ -51,7 +51,7 @@ def add(organization, aggregate_repository, token, refine):
 
 
 @cli.command()
-@click.argument('repository', required=False)
+@click.argument('repository')
 def update(repository):
     """Update all submodules inside the given aggregate repository.
 

--- a/conda_tracker/library.py
+++ b/conda_tracker/library.py
@@ -4,6 +4,8 @@ import re
 import git
 from github import Github
 
+from conda_tracker.utils import remove_submodule
+
 
 def create_aggregate_repository(repository_name, path='.'):
     """Create a new repository that will house all submodules.
@@ -136,13 +138,16 @@ def update_submodules(aggregate_repository):
     -------
     None
     """
-    aggregate_repository = git.Repo(aggregate_repository)
+    aggregate_repository_repo = git.Repo(aggregate_repository)
 
-    for submodule in aggregate_repository.submodules:
-        submodule.update()
-        aggregate_repository.index.add([submodule])
+    for submodule in aggregate_repository_repo.submodules:
+        try:
+            submodule.update()
+        except git.exc.GitCommandError:
+            print('Removing submodule {}' .format(submodule.name))
+            remove_submodule(aggregate_repository, submodule.name)
 
-    aggregate_repository.index.commit('Updated all submodules')
+    aggregate_repository_repo.index.commit('Updated all submodules')
 
 
 def gather_submodules(source_repository, aggregate_repository):

--- a/conda_tracker/library.py
+++ b/conda_tracker/library.py
@@ -121,8 +121,6 @@ def add_submodules(source_repository, aggregate_repository, refined_repositories
                                                   path=repository.name,
                                                   url=repository.clone_url)
 
-            aggregate_repository.index.add([repository.name])
-
     aggregate_repository.index.commit('Add submodules')
 
 

--- a/conda_tracker/utils.py
+++ b/conda_tracker/utils.py
@@ -1,0 +1,43 @@
+import os
+import shutil
+
+
+def remove_submodule(repository, submodule):
+    """Remove a submodule from a repository.
+
+    Because git does not currently include a command to remove
+    submodules, we have to edit the git files and remove the
+    submodule directory ourselves.
+
+    Parameters
+    ----------
+    repository: str
+        the path to the aggregate directory
+    submodule: str
+        the name of the submodule to remove
+
+    Returns
+    -------
+    None
+    """
+    submodule_path = os.path.join(os.path.abspath(repository), submodule)
+    gitmodules_path = os.path.join(os.path.abspath(repository), '.gitmodules')
+    config_path = os.path.join(os.path.abspath(repository), os.path.join('.git', 'config'))
+
+    with open(gitmodules_path) as gitmodules_file:
+        gitmodules = gitmodules_file.read().splitlines()
+
+    with open(config_path) as config_file:
+        config = config_file.read().splitlines()
+
+    with open(gitmodules_path, 'w') as gitmodules_file:
+        for line in gitmodules:
+            if submodule not in line:
+                gitmodules_file.write(line + '\n')
+
+    with open(config_path, 'w') as config_file:
+        for line in config:
+            if submodule not in line:
+                config_file.write(line + '\n')
+
+    shutil.rmtree(submodule_path)

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -31,6 +31,7 @@ def test_retrieve_organization_repositories():
 def test_add_submodules(tmpdir):
     library.create_aggregate_repository('test_aggregate_repo', tmpdir)
     aggregate_repository = os.path.join(tmpdir, 'test_aggregate_repo')
+    aggregate_repository_repo = git.Repo(aggregate_repository)
     conda_repositories = library.retrieve_organization_repositories('conda')
 
     library.add_submodules(conda_repositories, aggregate_repository)
@@ -38,6 +39,10 @@ def test_add_submodules(tmpdir):
     conda = ['conda', 'conda-build', 'conda-docs', 'conda-ui']
 
     assert all(repository in os.listdir(aggregate_repository) for repository in conda)
+    assert all((repository, 0) in aggregate_repository_repo.index.entries for repository in conda)
+    assert not aggregate_repository_repo.is_dirty()
+    assert len(aggregate_repository_repo.untracked_files) == 0
+    assert aggregate_repository_repo.head.commit.message == 'Add submodules'
 
 
 def test_update_submodules(tmpdir):

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -2,10 +2,11 @@ import os
 
 import git
 
-from conda_tracker import library
+from conda_tracker import library, utils
 
 
 def test_create_repository(tmpdir):
+    tmpdir = str(tmpdir)
     library.create_aggregate_repository('test_aggregate_repo', tmpdir)
     aggregate_repository = os.path.join(tmpdir, 'test_aggregate_repo')
 
@@ -28,7 +29,8 @@ def test_retrieve_organization_repositories():
     assert all(repository in repository_names for repository in conda)
 
 
-def test_add_submodules(tmpdir):
+def test_add_and_remove_submodules(tmpdir):
+    tmpdir = str(tmpdir)
     library.create_aggregate_repository('test_aggregate_repo', tmpdir)
     aggregate_repository = os.path.join(tmpdir, 'test_aggregate_repo')
     aggregate_repository_repo = git.Repo(aggregate_repository)
@@ -44,8 +46,13 @@ def test_add_submodules(tmpdir):
     assert len(aggregate_repository_repo.untracked_files) == 0
     assert aggregate_repository_repo.head.commit.message == 'Add submodules'
 
+    utils.remove_submodule(aggregate_repository, 'conda')
+
+    assert 'conda' not in os.listdir(aggregate_repository)
+
 
 def test_update_submodules(tmpdir):
+    tmpdir = str(tmpdir)
     library.create_aggregate_repository('test_aggregate_repo', tmpdir)
     aggregate_repository = os.path.join(tmpdir, 'test_aggregate_repo')
     aggregate_repository_repo = git.Repo(aggregate_repository)
@@ -69,6 +76,7 @@ def test_update_submodules(tmpdir):
 
 
 def test_gather_submodules(tmpdir):
+    tmpdir = str(tmpdir)
     library.create_aggregate_repository('test_aggregate_repo', tmpdir)
     aggregate_repository = os.path.join(tmpdir, 'test_aggregate_repo')
     aggregate_repository_repo = git.Repo(aggregate_repository)

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -74,6 +74,9 @@ def test_update_submodules(tmpdir):
 
     assert 'c272ad7f5a018495a8d60c05919c2ca396e7296f' in aggregate_repository_git.execute(['git', 'submodule'])
 
+    assert not aggregate_repository_repo.is_dirty()
+    assert len(aggregate_repository_repo.untracked_files) == 0
+
 
 def test_gather_submodules(tmpdir):
     tmpdir = str(tmpdir)


### PR DESCRIPTION
The CLI update subcommand now requires the user to pass the aggregate repository as an argument due to some unintended behavior when allowing the argument to be optional.

A remove_submodule function was added so that submodules with missing git revisions are deleted so that hard failures no longer occur.

Also, for some reason I had to use str(tmpdir) as a path for my tests to pass locally. I'm not sure why they would pass on the work machine. I recommend seeing if these tests pass locally for you before merging since CI won't run the tests for security reasons.

cc @msarahan 