### PR TITLE
Add remote flag to submodule update functions

### DIFF
--- a/conda_tracker/cli.py
+++ b/conda_tracker/cli.py
@@ -52,13 +52,14 @@ def add(organization, aggregate_repository, token, refine):
 
 @cli.command()
 @click.argument('repository')
-def update(repository):
+@click.option('--remote', is_flag=True)
+def update(repository, remote):
     """Update all submodules inside the given aggregate repository.
 
     Example:
     $  conda-tracker update
     """
-    library.update_submodules(repository)
+    library.update_submodules(repository, remote)
 
 
 @cli.command()

--- a/conda_tracker/library.py
+++ b/conda_tracker/library.py
@@ -126,7 +126,7 @@ def add_submodules(source_repository, aggregate_repository, refined_repositories
     aggregate_repository.index.commit('Add submodules')
 
 
-def update_submodules(aggregate_repository):
+def update_submodules(aggregate_repository, remote=False):
     """Update all of the submodules in the aggregate repository.
 
     Parameters
@@ -142,7 +142,7 @@ def update_submodules(aggregate_repository):
 
     for submodule in aggregate_repository_repo.submodules:
         try:
-            submodule.update()
+            submodule.update(to_latest_revision=remote)
         except git.exc.GitCommandError:
             print('Removing submodule {}' .format(submodule.name))
             remove_submodule(aggregate_repository, submodule.name)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,8 +23,8 @@ def test_cli_workflow():
         assert all(repository in os.listdir('my_agg_repo') for repository in conda_refined_repos)
         assert all(repository not in os.listdir('my_agg_repo') for repository in conda_omitted_repos)
 
-        update = runner.invoke(cli, ['update', 'my_agg_repo'])
-        
+        update = runner.invoke(cli, ['update', 'my_agg_repo', '--remote'])
+
         assert update.exit_code == 0
 
         gather = runner.invoke(cli, ['gather', 'conda', 'my_agg_repo'])


### PR DESCRIPTION
This PR adds a ``--remote`` flag to the CLI update subcommand. When the flag is given, every submodule in the specified aggregate repository will be updated to its latest revision.

This is the relevant GitPython API reference regarding the keyword argument that is called:
```
to_latest_revision – if True, the submodule’s sha will be ignored during checkout.
Instead, the remote will be fetched, and the local tracking branch updated.
This only works if we have a local tracking branch, 
which is the case if the remote repository had a master branch,
or of the ‘branch’ option was specified for 
this submodule and the branch existed remotely
```

All tests pass locally with my personal access token. 